### PR TITLE
Fixed python3 iteritems

### DIFF
--- a/ReadFromJSON.py
+++ b/ReadFromJSON.py
@@ -11,6 +11,12 @@ with open('melbpc-members3.json', 'r') as file:
   #more = members['values']
 
   for member in members.values():
-		print("Contact id:", member['contact_id'], " Name:", member['first_name'], member['last_name'], "Post Code:", member['postal_code'], "membership No.:", member['custom_8'], "Expiry Date:", member['membership_type_id'])
 	for api_Membership_get in member.items():
+        print((
+            "Contact id: {contact_id} "
+            "Name: {first_name} {last_name} "
+            "Post Code: {postal_code} "
+            "Membership No.: {custom_8} "
+            "Expiry Date: {membership_type_id}"
+        ).format(**member))
   #print(members)


### PR DESCRIPTION
The `dict.iteritems` method was removed in python3 (possibly later versions)

But mostly this is just a PR to get into the swing of contributing :wink: 