### PR TITLE
Bugfix: Google OAuth2 403 on single outside account

### DIFF
--- a/webapp/webapp/settings.py
+++ b/webapp/webapp/settings.py
@@ -107,6 +107,10 @@ SOCIALACCOUNT_PROVIDERS = {
     },
 }
 ACCOUNT_DEFAULT_HTTP_PROTOCOL = os.environ.get('DJANGO_ACCOUNT_DEFAULT_HTTP_PROTOCOL', 'http')
+SOCIAL_AUTH_GOOGLE_OAUTH2_AUTH_EXTRA_ARGUMENTS = {
+    # Bugfix: google oauth giving a 403 if only 1 (non melbpc) user is pre authorised on the device
+    'prompt': 'select_account',  # Force prompt to select account
+}
 
 if 'SITE_ID' in os.environ:
     globals()['SITE_ID'] = int(os.environ['SITE_ID'])

--- a/webapp/webapp/settings.py
+++ b/webapp/webapp/settings.py
@@ -103,14 +103,12 @@ SOCIALACCOUNT_PROVIDERS = {
         ],
         'AUTH_PARAMS': {
             'access_type': 'online',
+            # Bugfix: google oauth giving a 403 if only 1 (non melbpc) user is pre authorised on the device
+            'prompt': 'select_account',  # Force prompt to select account
         },
     },
 }
 ACCOUNT_DEFAULT_HTTP_PROTOCOL = os.environ.get('DJANGO_ACCOUNT_DEFAULT_HTTP_PROTOCOL', 'http')
-SOCIAL_AUTH_GOOGLE_OAUTH2_AUTH_EXTRA_ARGUMENTS = {
-    # Bugfix: google oauth giving a 403 if only 1 (non melbpc) user is pre authorised on the device
-    'prompt': 'select_account',  # Force prompt to select account
-}
 
 if 'SITE_ID' in os.environ:
     globals()['SITE_ID'] = int(os.environ['SITE_ID'])


### PR DESCRIPTION
## Problem Description
Regarding users already logged in with a google account.
If a user:
- auth'd on no accounts, they're asked to login :heavy_check_mark: 
- auth'd on multiple accounts, they're asked which account, or to login to another :heavy_check_mark: 
- auth'd on one account, specifically a `melbpc.org.au` account :heavy_check_mark: (straight through to app)
- auth'd on one account, **not** `melbpc.org.au` :x: (error 403 due to account *not* being from `melbpc.org.au`)

## Solution
Add a parameter to the URL used to contact google for authentication, forcing them to select an account (even if there's only one).