### PR TITLE
Feature: Use nginx in development

### DIFF
--- a/.dc.dev.yml
+++ b/.dc.dev.yml
@@ -1,18 +1,32 @@
 version: '3.7'
 
 services:
+  nginx:
+    image: nginx:1.20-alpine
+    ports:
+      - 80:80
+      - 443:443
+    volumes:
+      # nginx config
+      - ./nginx.dev.conf:/etc/nginx/conf.d/default.conf
+      # https certs (same as staged)
+      - ./env/staged-letsencrypt/:/etc/letsencrypt/
+    depends_on:
+      - django
+      - vue
+
   # Web frontend - Vue application
   vue:
     build: ./frontend
     volumes:
       - ./frontend/:/code/
       - frontend_libs:/code/node_modules/
+    environment:
+      - VUE_PUBLIC_PATH=/app/
     env_file:
       - ./env/dev.env
     depends_on:
       - django
-    ports:
-      - 8080:8080
     command: npm run serve
 
   # Web backend - Django
@@ -21,8 +35,6 @@ services:
     command: python manage.py runserver 0.0.0.0:8000
     volumes:
       - ./webapp/:/code/
-    ports:
-      - 8000:8000
     env_file:
       - ./env/dev.env
       - ./env/civicrm.env

--- a/env/staged-letsencrypt/live/localhost/generate-certs.sh
+++ b/env/staged-letsencrypt/live/localhost/generate-certs.sh
@@ -3,7 +3,7 @@ set -e
 rsa_key_size=4096
 path=$(dirname $0)
 
-openssl req -x509 -nodes -newkey rsa:$rsa_key_size -days 1 \
+openssl req -x509 -nodes -newkey rsa:$rsa_key_size -days 365 \
     -keyout "$path/privkey.pem" \
     -out "$path/fullchain.pem" \
     -subj "/CN=localhost"

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -11,20 +11,6 @@ module.exports = {
   devServer: {
     host: '0.0.0.0',
     port: 8080,
-    proxy: {
-      "/api": {
-        target: `http://${process.env.API_HOST || "127.0.0.1:8080"}`,
-        changeOrigin: true,
-        secure: false,
-        logLevel: 'debug',
-      },
-      "/token": {
-        target: `http://${process.env.API_HOST || "127.0.0.1:8080"}`,
-        changeOrigin: true,
-        secure: false,
-        logLevel: 'debug',
-      },
-    },
     progress: false, // ref: https://github.com/vuejs/vue-cli/issues/4557#issuecomment-545965828
   },
   outputDir: process.env.VUE_OUTPUT_DIR || "dist",

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -11,7 +11,6 @@ module.exports = {
   devServer: {
     host: '0.0.0.0',
     port: 8080,
-    https: true, // required to enable camera
     proxy: {
       "/api": {
         target: `http://${process.env.API_HOST || "127.0.0.1:8080"}`,

--- a/nginx.dev.conf
+++ b/nginx.dev.conf
@@ -2,14 +2,14 @@ upstream django_app {
     server django:8000;
 }
 
+upstream vue_app {
+    server vue:8080;
+}
+
 server {
     listen 80;
     server_name localhost;
     server_tokens off;
-
-    location /.well-known/acme-challenge/ {
-        root /var/www/certbot;
-    }
 
     location / {
         return 301 https://$host$request_uri;
@@ -21,7 +21,7 @@ server {
     server_name localhost;
     server_tokens off;
 
-    # Stage cert's: (use stage certs)
+    # Development cert's: (use stage cert's)
     #   Certificate is set to expire 1 year after creation, if a new
     #   one is required, generate it with:
     #       $ env/staged-letsencrypt/live/localhost/generate-certs.sh
@@ -38,15 +38,23 @@ server {
         proxy_redirect off;
     }
 
-    location /static/ {
-        alias /srv/prod/static/;
-    }
-
+    # Vue dev server:
+    #   Configuration is based on the following:
+    #       ref: https://medium.com/homullus/vuejs-dev-serve-with-reverse-proxy-cdc3c9756aeb
+    #       ref: https://github.com/markomitranic/Kaputt-app/blob/master/Docker/nginx/conf/kaputt-dev.conf
     location /app/ {
-        alias /srv/prod/frontend/dist/;
-        try_files $uri /index.html =404;
-        # FIXME: any invlaid files will serve index.html.
-        #   This will be a problem when a user has a cached frontend;
-        #   all .js, and .css files they request will have html content.
+        proxy_pass http://vue_app;
+        proxy_set_header Host localhost;
+        proxy_set_header Origin localhost;
+        proxy_hide_header Access-Control-Allow-Origin;
+    }
+    location /sockjs-node/ {
+        proxy_pass http://vue_app;
+        proxy_set_header Host localhost;
+        proxy_set_header Origin localhost;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_hide_header Access-Control-Allow-Origin;
     }
 }

--- a/nginx.prod.conf
+++ b/nginx.prod.conf
@@ -7,6 +7,10 @@ server {
     server_name attend.melbpc.org.au;
     server_tokens off;
 
+    # Certbot via port 80 : reading
+    #   ref: https://community.letsencrypt.org/t/renewal-acme-challenge-over-https/79482
+    #   ref: https://letsencrypt.org/docs/allow-port-80/
+
     # Uncomment next line to initialise SSL cert (HTTPS):
     #   - when first setting up server
     #   - if certificate expired & needs refreshing

--- a/nginx.prod.conf
+++ b/nginx.prod.conf
@@ -7,9 +7,10 @@ server {
     server_name attend.melbpc.org.au;
     server_tokens off;
 
-    location /.well-known/acme-challenge/ {
-        root /var/www/certbot;
-    }
+    # Uncomment next line to initialise SSL cert (HTTPS):
+    #   - when first setting up server
+    #   - if certificate expired & needs refreshing
+    #location /.well-known/acme-challenge/ { root /var/www/certbot; }
 
     location / {
         return 301 https://$host$request_uri;
@@ -25,6 +26,8 @@ server {
     ssl_certificate_key /etc/letsencrypt/live/attend.melbpc.org.au/privkey.pem;
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    location /.well-known/acme-challenge/ { root /var/www/certbot; }
 
     location / {
         proxy_pass http://django_app;

--- a/webapp/crontab
+++ b/webapp/crontab
@@ -1,3 +1,3 @@
 # min   hour    day     month   weekday command
-*       */6     *       *       *       python /srv/app/manage.py import_civicrm
+0       */6     *       *       *       python /srv/app/manage.py import_civicrm
 */5     *       *       *       *       python /srv/app/manage.py export_attendance --quiet


### PR DESCRIPTION
## Original Devlopment Arch'

Before this change a developer would pass through vue's dev backend to get to the backend APIs... via port 8080.
Everything purely backend related would be through port 8000.

- Vue Dev Server: https on `8080` (https required for camera to work on browsers)
   - `/api` proxied to to `8000`
   - `/token` proxied to `8000`
   - `/` everything else, straight to `8080`
- Django Dev Server : http on `8000`

## New Development Architecture

Now the development server should behave much like production:

- Nginx : `80` forwarded to `433`
   - `/app` proxied to vue dev server
   - `/` everything else, to django dev server

It's a little more complex than that... but overall much simpler, and easier to build new interfaces should they arrise.
Also, all links from `/app` (including `/admin`, `/api`, and `/logout` work out of the box)